### PR TITLE
Guest and User Cart/Checkout Stable

### DIFF
--- a/client/components/AllProducts.js
+++ b/client/components/AllProducts.js
@@ -3,7 +3,7 @@ import axios from 'axios'
 import {getProductView} from '../store/viewProduct'
 import {connect} from 'react-redux'
 import FullPageSingleProduct from './SingleProductFullPageView'
-import {populateGuestCart} from '../store'
+import {populateGuestCart, getCartFromServer} from '../store'
 
 //Components
 import {SingleProduct} from './SingleProduct'
@@ -47,13 +47,14 @@ class AllProducts extends React.Component {
         `/api/users/${this.props.user.id}/addToCart`,
         `productId=${id}`
       )
+      this.props.updateUserCart(this.props.user.id)
     } else {
       //GUEST
       let oldCart = JSON.parse(localStorage.getItem('cart'))
       if (!oldCart) oldCart = []
       oldCart.push(id)
       localStorage.setItem('cart', JSON.stringify(oldCart))
-      this.props.updateGuestCart(oldCart)
+      this.props.updateGuestCart()
     }
   }
 }
@@ -72,8 +73,11 @@ const mapDispatchToProps = dispatch => {
       event.preventDefault()
       dispatch(getProductView(productId))
     },
-    updateGuestCart(cart) {
-      dispatch(populateGuestCart(cart))
+    updateGuestCart() {
+      dispatch(populateGuestCart())
+    },
+    updateUserCart(userId) {
+      dispatch(getCartFromServer(userId))
     }
   }
 }

--- a/client/components/AllProducts.js
+++ b/client/components/AllProducts.js
@@ -3,6 +3,7 @@ import axios from 'axios'
 import {getProductView} from '../store/viewProduct'
 import {connect} from 'react-redux'
 import FullPageSingleProduct from './SingleProductFullPageView'
+import {populateGuestCart} from '../store'
 
 //Components
 import {SingleProduct} from './SingleProduct'
@@ -52,6 +53,7 @@ class AllProducts extends React.Component {
       if (!oldCart) oldCart = []
       oldCart.push(id)
       localStorage.setItem('cart', JSON.stringify(oldCart))
+      this.props.updateGuestCart(oldCart)
     }
   }
 }
@@ -69,6 +71,9 @@ const mapDispatchToProps = dispatch => {
     viewFullProduct(productId) {
       event.preventDefault()
       dispatch(getProductView(productId))
+    },
+    updateGuestCart(cart) {
+      dispatch(populateGuestCart(cart))
     }
   }
 }

--- a/client/components/ShoppingCart.js
+++ b/client/components/ShoppingCart.js
@@ -16,13 +16,21 @@ import {me} from '../store'
 import {withRouter} from 'react-router-dom'
 
 class ShoppingCart extends React.Component {
+  componentDidUpdate() {
+    console.log('ShoppingCart Updated. Cart:', this.props.cart)
+  }
+
   componentDidMount() {
     // if (!this.props.user) this.props.getMe()
     if (!this.props.user.id) {
       // console.log('about to populate guest cart on state')
-      let localStorageCart = JSON.parse(localStorage.getItem('cart'))
-      console.log('local storage:', localStorageCart)
-      this.props.setGuestCart(localStorageCart)
+      console.log('ShoppingCart Mounted')
+      console.log('props.cart:', this.props.cart)
+      // let localStorageCart = JSON.parse(localStorage.getItem('cart'))
+      console.log('local storage:', JSON.parse(localStorage.getItem('cart')))
+      this.props.setGuestCart()
+      console.log('props.cart after dispatch:', this.props.cart)
+      // this.props.history.push('/cart')
       // console.log('Cart at end of mounting:', this.props.cart)
     }
   }
@@ -94,9 +102,14 @@ class ShoppingCart extends React.Component {
       let cart = JSON.parse(localStorage.getItem('cart'))
       console.log('Current cart', cart)
       if (!cart) cart = []
-      axios.put('/api/guests/placeOrder', {cart})
-      localStorage.setItem('cart', JSON.stringify([]))
-      this.props.setGuestCart([])
+      axios
+        .put('/api/guests/placeOrder', {cart})
+        .then(() => localStorage.setItem('cart', JSON.stringify([])))
+        .then(() => this.props.setGuestCart([]))
+        .catch(err => {
+          console.log(err)
+        })
+      // this.props.setGuestCart([])
     }
   }
 }

--- a/client/components/ShoppingCart.js
+++ b/client/components/ShoppingCart.js
@@ -17,13 +17,13 @@ import {withRouter} from 'react-router-dom'
 
 class ShoppingCart extends React.Component {
   componentDidMount() {
-    if (!this.props.user) this.props.getMe()
+    // if (!this.props.user) this.props.getMe()
     if (!this.props.user.id) {
-      console.log('about to populate guest cart on state')
+      // console.log('about to populate guest cart on state')
       let localStorageCart = JSON.parse(localStorage.getItem('cart'))
       console.log('local storage:', localStorageCart)
       this.props.setGuestCart(localStorageCart)
-      console.log('Cart at end of mounting:', this.props.cart)
+      // console.log('Cart at end of mounting:', this.props.cart)
     }
   }
   render() {
@@ -92,8 +92,11 @@ class ShoppingCart extends React.Component {
     } else {
       //GUEST
       let cart = JSON.parse(localStorage.getItem('cart'))
+      console.log('Current cart', cart)
       if (!cart) cart = []
       axios.put('/api/guests/placeOrder', {cart})
+      localStorage.setItem('cart', JSON.stringify([]))
+      this.props.setGuestCart([])
     }
   }
 }

--- a/client/components/ShoppingCart.js
+++ b/client/components/ShoppingCart.js
@@ -11,13 +11,20 @@ import {
   Button
 } from '@material-ui/core'
 import DeleteIcon from '@material-ui/icons/Delete'
-import {checkoutOnServer} from '../store/cartState'
+import {checkoutOnServer, populateGuestCart} from '../store/cartState'
 import {me} from '../store'
 import {withRouter} from 'react-router-dom'
 
 class ShoppingCart extends React.Component {
   componentDidMount() {
-    this.props.getMe()
+    if (!this.props.user) this.props.getMe()
+    if (!this.props.user.id) {
+      console.log('about to populate guest cart on state')
+      let localStorageCart = JSON.parse(localStorage.getItem('cart'))
+      console.log('local storage:', localStorageCart)
+      this.props.setGuestCart(localStorageCart)
+      console.log('Cart at end of mounting:', this.props.cart)
+    }
   }
   render() {
     return (
@@ -108,6 +115,9 @@ const mapDispatch = dispatch => {
     },
     checkout(userId) {
       dispatch(checkoutOnServer(userId))
+    },
+    setGuestCart(cart) {
+      dispatch(populateGuestCart(cart))
     }
   }
 }

--- a/client/components/ShoppingCart.js
+++ b/client/components/ShoppingCart.js
@@ -31,18 +31,17 @@ class ShoppingCart extends React.Component {
   }
   componentDidMount() {
     // if (!this.props.user) this.props.getMe()
-    if (!this.props.user.id) {
-      // console.log('about to populate guest cart on state')
-      console.log('ShoppingCart Mounted')
-      console.log('props.cart:', this.props.cart)
-      // let localStorageCart = JSON.parse(localStorage.getItem('cart'))
-      console.log('local storage:', JSON.parse(localStorage.getItem('cart')))
-      this.props.setGuestCart()
-      console.log('props.cart after dispatch:', this.props.cart)
-      // this.props.history.push('/cart')
-      // console.log('Cart at end of mounting:', this.props.cart)
-    }
+    console.log('ShoppingCart Mounted. Cart:', this.props.cart)
+    // console.log('about to populate guest cart on state')
+
+    // let localStorageCart = JSON.parse(localStorage.getItem('cart'))
+    // console.log('local storage:', JSON.parse(localStorage.getItem('cart')))
+    // this.props.setGuestCart()
+    // console.log('props.cart after dispatch:', this.props.cart)
+    // this.props.history.push('/cart')
+    // console.log('Cart at end of mounting:', this.props.cart)
   }
+  // }
   handleClose() {
     this.setState({
       dialogOpen: false
@@ -131,7 +130,7 @@ class ShoppingCart extends React.Component {
       axios
         .put('/api/guests/placeOrder', {cart})
         .then(() => localStorage.setItem('cart', JSON.stringify([])))
-        .then(() => this.props.setGuestCart([]))
+        .then(() => this.props.setGuestCart())
         .catch(err => {
           console.log(err)
         })
@@ -158,9 +157,6 @@ const mapState = state => {
 
 const mapDispatch = dispatch => {
   return {
-    getMe() {
-      dispatch(me())
-    },
     checkout(userId) {
       dispatch(checkoutOnServer(userId))
     },

--- a/client/components/auth-form.js
+++ b/client/components/auth-form.js
@@ -63,7 +63,7 @@ const AuthForm = props => {
           </FormControl>
           <FormControl margin="normal" required>
             <InputLabel htmlFor="password">Password</InputLabel>
-            <Input id="password" name="password" />
+            <Input id="password" type="password" name="password" />
           </FormControl>
           <Button type="submit" style={submitStyles}>
             Submit

--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -40,7 +40,11 @@ class Navbar extends React.Component {
               to="/products"
             />
             <Tab label="Profile" component={Link} to="/home" />
-            <Tab label="Cart" component={Link} to="/cart" />
+            <Tab
+              label={`Cart (${this.props.cart.productOrders.length})`}
+              component={Link}
+              to="/cart"
+            />
             <Tab label="Login" component={Link} to="/login" />
           </Tabs>
         </AppBar>
@@ -55,7 +59,7 @@ class Navbar extends React.Component {
 const mapState = state => {
   return {
     isLoggedIn: !!state.user.id,
-    tab: state.tab
+    cart: state.cart
   }
 }
 

--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -2,17 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
 import OrderHistory from './OrderHistory'
-import {
-  Card,
-  CardContent,
-  CardMedia,
-  Typography,
-  IconButton
-} from '@material-ui/core'
-import Button from '@material-ui/core/Button'
-
-// Components
-import AllProducts from './AllProducts'
+import {Typography, Button} from '@material-ui/core'
+import {logout} from '../store'
 
 /**
  * COMPONENT
@@ -25,6 +16,11 @@ export const UserHome = props => {
       <Typography color="primary" variant="h2">
         Welcome {name} to Duck Sales!
       </Typography>
+      <div className="details">
+        <Button color="secondary" variant="outlined" onClick={props.logMeOut}>
+          Logout
+        </Button>
+      </div>
       <div className="details">
         <Typography variant="h4">Profile Details</Typography>
       </div>
@@ -57,7 +53,15 @@ const mapState = state => {
   }
 }
 
-export default connect(mapState)(UserHome)
+const mapDispatch = dispatch => {
+  return {
+    logMeOut() {
+      dispatch(logout())
+    }
+  }
+}
+
+export default connect(mapState, mapDispatch)(UserHome)
 
 /**
  * PROP TYPES

--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
+import {Redirect} from 'react-router-dom'
 import OrderHistory from './OrderHistory'
 import {Typography, Button} from '@material-ui/core'
 import {logout} from '../store'

--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
-import {Redirect} from 'react-router-dom'
+// import {Redirect} from 'react-router-dom'
 import OrderHistory from './OrderHistory'
 import {Typography, Button} from '@material-ui/core'
 import {logout} from '../store'

--- a/client/routes.js
+++ b/client/routes.js
@@ -12,7 +12,12 @@ import ShoppingCart from './components/ShoppingCart'
  */
 class Routes extends Component {
   componentDidMount() {
+    console.log('Routes Mounted')
     this.props.loadInitialData()
+  }
+
+  componentDidUpdate() {
+    console.log('Routes Updated. Cart:', this.props.cart)
   }
 
   render() {
@@ -43,7 +48,8 @@ const mapState = state => {
     // Being 'logged in' for our purposes will be defined has having a state.user that has a truthy id.
     // Otherwise, state.user will be an empty object, and state.user.id will be falsey
     isLoggedIn: !!state.user.id,
-    user: state.user
+    user: state.user,
+    cart: state.cart
   }
 }
 

--- a/client/routes.js
+++ b/client/routes.js
@@ -14,10 +14,15 @@ class Routes extends Component {
   componentDidMount() {
     console.log('Routes Mounted')
     this.props.loadInitialData()
+    // console.log('user id:', this.props.user.id)
+    // if(!this.props.user.id) {
+    //   this.props.setGuestCart()
+    // }
   }
 
   componentDidUpdate() {
     console.log('Routes Updated. Cart:', this.props.cart)
+    console.log('User:', this.props.user.id)
   }
 
   render() {

--- a/client/routes.js
+++ b/client/routes.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, Route, Switch} from 'react-router-dom'
+import {withRouter, Route, Switch, Redirect} from 'react-router-dom'
 import PropTypes from 'prop-types'
 import {Login, Signup, UserHome} from './components'
 import {me, getAllProductsFromServer} from './store'
@@ -20,19 +20,16 @@ class Routes extends Component {
     return (
       <Switch>
         {/* Routes placed here are available to all visitors */}
-        <Route exact path="/" component={AllProducts} />
+        {/* <Route exact path="/" component={AllProducts} /> */}
         <Route path="/login" component={Login} />
         <Route path="/signup" component={Signup} />
         <Route path="/products" component={AllProducts} />
         <Route path="/cart" component={ShoppingCart} />
-        {isLoggedIn && (
-          <Switch>
-            {/* Routes placed here are only available after logging in */}
-            <Route path="/home" component={UserHome} />
-          </Switch>
-        )}
-        {/* Displays our Login component as a fallback */}
-        <Route component={AllProducts} />
+        <Route
+          path="/home"
+          render={() => (isLoggedIn ? <UserHome /> : <Login />)}
+        />
+        <Route render={() => <Redirect to="/products" />} />
       </Switch>
     )
   }

--- a/client/store/cartState.js
+++ b/client/store/cartState.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import {array} from 'prop-types'
 
 // Initial Cart State
 const initialCart = {productOrders: []}

--- a/client/store/cartState.js
+++ b/client/store/cartState.js
@@ -28,6 +28,11 @@ export const getCartFromServer = userId => {
   return async dispatch => {
     try {
       const res = await axios.get(`/api/users/${userId}/cart`)
+      console.log(
+        'Finished fetching user cart, dispatching:',
+        res.data.productOrders
+      )
+      if (!res.data.productOrders) res.data.productOrders = []
       const cart = res.data
       dispatch(gotCart(cart))
     } catch (err) {
@@ -66,6 +71,7 @@ export const checkoutOnServer = userId => {
   return async dispatch => {
     try {
       await axios.put(`/api/users/${userId}/placeOrder`)
+      console.log('Finished posting order, dispatching state change.')
       dispatch(getCartFromServer(userId))
     } catch (err) {
       console.log(err.message)

--- a/client/store/cartState.js
+++ b/client/store/cartState.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import {array} from 'prop-types'
+import {array, arrayOf} from 'prop-types'
 
 // Initial Cart State
 const initialCart = {productOrders: []}
@@ -40,6 +40,7 @@ export const populateGuestCart = () => {
   return dispatch => {
     const guestCart = initialCart
     let arrayOfProductIds = JSON.parse(localStorage.getItem('cart'))
+    if (!arrayOfProductIds) arrayOfProductIds = []
 
     Promise.all(
       arrayOfProductIds.map(id => {

--- a/client/store/cartState.js
+++ b/client/store/cartState.js
@@ -36,9 +36,11 @@ export const getCartFromServer = userId => {
   }
 }
 
-export const populateGuestCart = arrayOfProductIds => {
+export const populateGuestCart = () => {
   return dispatch => {
     const guestCart = initialCart
+    let arrayOfProductIds = JSON.parse(localStorage.getItem('cart'))
+
     Promise.all(
       arrayOfProductIds.map(id => {
         // console.log(id)
@@ -75,7 +77,7 @@ export default function(state = initialCart, action) {
     case GET_CART:
       return {...state, ...action.cart}
     case SET_GUEST_CART:
-      return action.cart
+      return {...state, ...action.cart}
     default:
       return state
   }

--- a/client/store/cartState.js
+++ b/client/store/cartState.js
@@ -5,11 +5,19 @@ const initialCart = {productOrders: []}
 
 // Action constants
 const GET_CART = 'GET_CART'
+const SET_GUEST_CART = 'SET_GUEST_CART'
 
 // Action creators
 const gotCart = cart => {
   return {
     type: GET_CART,
+    cart
+  }
+}
+
+const setGuestCart = cart => {
+  return {
+    type: SET_GUEST_CART,
     cart
   }
 }
@@ -27,6 +35,29 @@ export const getCartFromServer = userId => {
   }
 }
 
+export const populateGuestCart = arrayOfProductIds => {
+  return dispatch => {
+    const guestCart = initialCart
+    Promise.all(
+      arrayOfProductIds.map(id => {
+        // console.log(id)
+        return axios.get(`/api/products/${id}`)
+        // console.log('Product Data:', product.data)
+      })
+    )
+      .then(products => {
+        guestCart.productOrders = products.map(order => {
+          return {product: order.data}
+        })
+        return guestCart
+      })
+      .then(cart => dispatch(setGuestCart(cart)))
+      .catch(err => {
+        console.log(err)
+      })
+  }
+}
+
 export const checkoutOnServer = userId => {
   return async dispatch => {
     try {
@@ -41,7 +72,9 @@ export const checkoutOnServer = userId => {
 export default function(state = initialCart, action) {
   switch (action.type) {
     case GET_CART:
-      return {productOrders: [], ...action.cart}
+      return {...state, ...action.cart}
+    case SET_GUEST_CART:
+      return action.cart
     default:
       return state
   }

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -20,5 +20,5 @@ const store = createStore(reducer, middleware)
 
 export default store
 export * from './user'
-export {getCartFromServer} from './cartState'
+export * from './cartState'
 export {getAllProductsFromServer} from './allProducts'

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -51,6 +51,7 @@ export const auth = (email, password, method) => async dispatch => {
 
 export const logout = () => async dispatch => {
   try {
+    console.log('logout thunk hit')
     await axios.post('/auth/logout')
     dispatch(removeUser())
     history.push('/login')

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -27,7 +27,7 @@ export const me = () => async dispatch => {
   try {
     const res = await axios.get('/auth/me')
     await dispatch(getUser(res.data || defaultUser))
-    await dispatch(getCartFromServer(res.data.id))
+    if (res.data) dispatch(getCartFromServer(res.data.id))
   } catch (err) {
     console.error(err)
   }

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -26,9 +26,9 @@ const removeUser = () => ({type: REMOVE_USER})
 export const me = () => async dispatch => {
   try {
     const res = await axios.get('/auth/me')
-    await dispatch(getUser(res.data || defaultUser))
+    dispatch(getUser(res.data || defaultUser))
     if (res.data.id) dispatch(getCartFromServer(res.data.id))
-    // else dispatch(populateGuestCart(JSON.parse(localStorage.getItem('cart')) || []))
+    else dispatch(populateGuestCart())
   } catch (err) {
     console.error(err)
   }
@@ -44,6 +44,7 @@ export const auth = (email, password, method) => async dispatch => {
 
   try {
     dispatch(getUser(res.data))
+    dispatch(getCartFromServer(res.data.id))
     history.push('/home')
   } catch (dispatchOrHistoryErr) {
     console.error(dispatchOrHistoryErr)
@@ -55,6 +56,7 @@ export const logout = () => async dispatch => {
     console.log('logout thunk hit')
     await axios.post('/auth/logout')
     dispatch(removeUser())
+    dispatch(populateGuestCart())
     history.push('/login')
   } catch (err) {
     console.error(err)

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import history from '../history'
 
-import {getCartFromServer} from './cartState'
+import {getCartFromServer, populateGuestCart} from './cartState'
 
 /**
  * ACTION TYPES
@@ -27,7 +27,8 @@ export const me = () => async dispatch => {
   try {
     const res = await axios.get('/auth/me')
     await dispatch(getUser(res.data || defaultUser))
-    if (res.data) dispatch(getCartFromServer(res.data.id))
+    if (res.data.id) dispatch(getCartFromServer(res.data.id))
+    // else dispatch(populateGuestCart(JSON.parse(localStorage.getItem('cart')) || []))
   } catch (err) {
     console.error(err)
   }

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -43,8 +43,9 @@ router.post('/logout', (req, res) => {
 })
 
 router.get('/me', (req, res) => {
-  console.log('The initial user is', req.user.name)
-  res.json(req.user)
+  // console.log('The initial user is', req.user.name)
+  if (req.user) res.json(req.user)
+  else res.json({})
 })
 
 router.use('/google', require('./google'))


### PR DESCRIPTION
Current Full User Story:
Go to site as guest. Cart has 0 ducks. Add a duck to cart, cart immediately has one duck and navbar updates to show (1) on cart tab without refresh. Navigating to cart page shows the one duck.

User then logs in/signs up, on hitting submit they are redirected to their profile page, with their cart and the cart tab immediately updated. Assuming it's a new user, it will be 0 ducks. User then goes to products page and adds 2 ducks. Cart and tab are updated automatically on each press of add-to-cart button.

User logs out. They are redirected to login page, and cart now shows the 1 duck in their guest cart. The user logs back in, they are redirected to their profile page and their cart is updated with the 2 ducks in their user cart.

User checks out their user cart, the page clears all ducks and tab shows 0. Database is updated. User logs out, cart is updated to show the one duck in their guest cart. User checks out their guest cart, the page clears the duck and tab shows 0, database is updated. Rinse repeat. No refresh ever necessary, refresh never breaks anything.